### PR TITLE
Update to DeepSpeech v0.7.1 (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 Golang bindings for Mozilla's [DeepSpeech](https://github.com/mozilla/DeepSpeech) speech-to-text library.
 
-As of now, `astideepspeech` is only compatible with version `v0.6.0` of `DeepSpeech`.
+`astideepspeech` is compatible with version `v0.7.1` of `DeepSpeech`.
 
 # Installation
 ## Install DeepSpeech
 
-- fetch an up-to-date `native_client.<your system>.tar.xz` matching your system from DeepSpeech's ["releases"](https://github.com/mozilla/DeepSpeech/releases/tag/v0.6.0)
+- fetch an up-to-date `native_client.<your system>.tar.xz` matching your system from DeepSpeech's ["releases"](https://github.com/mozilla/DeepSpeech/releases/tag/v0.7.1)
 - extract its content to /tmp/deepspeech/lib
-- download `deepspeech.h` from https://github.com/mozilla/DeepSpeech/raw/v0.6.0/native_client/deepspeech.h
+- download `deepspeech.h` from https://github.com/mozilla/DeepSpeech/raw/v0.7.1/native_client/deepspeech.h
 - copy it to /tmp/deepspeech/include
 - export CGO_LDFLAGS="-L/tmp/deepspeech/lib/"
 - export CGO_CXXFLAGS="-I/tmp/deepspeech/include/"
@@ -23,36 +23,36 @@ Run the following command:
     $ go get -u github.com/asticode/go-astideepspeech/...
     
 # Example
-## Get the pre-trained model
+## Get the pre-trained model and scorer
 
 Run the following commands:
 
     $ mkdir /tmp/deepspeech
     $ cd /tmp/deepspeech
-    $ wget https://github.com/mozilla/DeepSpeech/releases/download/v0.6.0/deepspeech-0.6.0-models.tar.gz
-    $ tar xvfz deepspeech-0.6.0-models.tar.gz
+    $ wget https://github.com/mozilla/DeepSpeech/releases/download/v0.7.1/deepspeech-0.7.1-models.pbmm
+    $ wget https://github.com/mozilla/DeepSpeech/releases/download/v0.7.1/deepspeech-0.7.1-models.scorer
     
 ## Get the audio files
 
 Run the following commands:
 
     $ cd /tmp/deepspeech
-    $ wget https://github.com/mozilla/DeepSpeech/releases/download/v0.6.0/audio-0.6.0.tar.gz
-    $ tar xvfz audio-0.6.0.tar.gz
+    $ wget https://github.com/mozilla/DeepSpeech/releases/download/v0.7.1/audio-0.7.1.tar.gz
+    $ tar xvfz audio-0.7.1.tar.gz
     
 ## Use the client
 
 Run the following commands (make sure `$GOPATH/bin` is in your `$PATH`):
 
     $ cd /tmp/deepspeech
-    $ deepspeech -model models/output_graph.pb -audio audio/2830-3980-0043.wav -lm models/lm.binary -trie models/trie
+    $ deepspeech -model deepspeech-0.7.1-models.pbmm -scorer deepspeech-0.7.1-models.scorer -audio audio/2830-3980-0043.wav
     
         Text: experience proves this
     
-    $ deepspeech -model models/output_graph.pb -audio audio/4507-16021-0012.wav -lm models/lm.binary -trie models/trie
+    $ deepspeech -model deepspeech-0.7.1-models.pbmm -scorer deepspeech-0.7.1-models.scorer -audio audio/4507-16021-0012.wav
     
-        Text: why should one halt on the way
+        Text: why should one hall on the way
         
-    $ deepspeech -model models/output_graph.pb -audio audio/8455-210777-0068.wav -lm models/lm.binary -trie models/trie
+    $ deepspeech -model deepspeech-0.7.1-models.pbmm -scorer deepspeech-0.7.1-models.scorer -audio audio/8455-210777-0068.wav
     
         Text: your power is sufficient i said

--- a/deepspeech_wrap.h
+++ b/deepspeech_wrap.h
@@ -1,45 +1,59 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    typedef struct MetadataItem {
-        char* character;
-        int timestep;
-        float start_time;
-    } MetadataItem;
+    typedef struct TokenMetadata {
+        const char* text;
+        const unsigned int timestep;
+        const float start_time;
+    } TokenMetadata;
+
+    typedef struct CandidateTranscript {
+        const TokenMetadata* const tokens;
+        const unsigned int num_tokens;
+        const double confidence;
+    } CandidateTranscript;
 
     typedef struct Metadata {
-        MetadataItem* items;
-        int num_items;
-        double confidence;
+        const CandidateTranscript* const transcripts;
+        const unsigned int num_transcripts;
     } Metadata;
 
     typedef void* ModelWrapper;
-    ModelWrapper* New(const char* aModelPath, int aBeamWidth);
+    ModelWrapper* New(const char* aModelPath);
     void Close(ModelWrapper* w);
-    void EnableDecoderWithLM(ModelWrapper* w, const char* aLMPath, const char* aTriePath, float aLMWeight, float aValidWordCountWeight);
+    unsigned int GetModelBeamWidth(ModelWrapper* w);
+    int SetModelBeamWidth(ModelWrapper* w, unsigned int aBeamWidth);
     int GetModelSampleRate(ModelWrapper* w);
+    int EnableExternalScorer(ModelWrapper* w, const char* aScorerPath);
+    int DisableExternalScorer(ModelWrapper* w);
+    int SetScorerAlphaBeta(ModelWrapper* w, float aAlpha, float aBeta);
     char* STT(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize);
-    Metadata* STTWithMetadata(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize);
+    Metadata* STTWithMetadata(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize, unsigned int aNumResults);
 
     typedef void* StreamWrapper;
     StreamWrapper* CreateStream(ModelWrapper* w);
     void FreeStream(StreamWrapper* sw);
     void FeedAudioContent(StreamWrapper* sw, const short* aBuffer, unsigned int aBufferSize);
     char* IntermediateDecode(StreamWrapper* sw);
+    Metadata* IntermediateDecodeWithMetadata(StreamWrapper* sw, unsigned int aNumResults);
     char* FinishStream(StreamWrapper* sw);
-    Metadata* FinishStreamWithMetadata(StreamWrapper* sw);
+    Metadata* FinishStreamWithMetadata(StreamWrapper* sw, unsigned int aNumResults);
 
-    MetadataItem* Metadata_GetItems(Metadata* m);
-    double Metadata_GetConfidence(Metadata* m);
-    int Metadata_GetNumItems(Metadata* m);
+    const CandidateTranscript* Metadata_GetTranscripts(Metadata* m);
+    unsigned int Metadata_GetNumTranscripts(Metadata* m);
 
-    char* MetadataItem_GetCharacter(MetadataItem* mi);
-    int MetadataItem_GetTimestep(MetadataItem* mi);
-    float MetadataItem_GetStartTime(MetadataItem* mi);
+    const TokenMetadata* CandidateTranscript_GetTokens(CandidateTranscript* ct);
+    unsigned int CandidateTranscript_GetNumTokens(CandidateTranscript* ct);
+    double CandidateTranscript_GetConfidence(CandidateTranscript* ct);
+
+    const char* TokenMetadata_GetText(TokenMetadata* tm);
+    unsigned int TokenMetadata_GetTimestep(TokenMetadata* tm);
+    float TokenMetadata_GetStartTime(TokenMetadata* tm);
 
     void FreeString(char* s);
     void FreeMetadata(Metadata* m);
-    void PrintVersions();
+    char* Version();
+    char* ErrorCodeToErrorMessage(int aErrorCode);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Make non-backward-compatible changes to link against v0.7.1
of the DeepSpeech C library. Notable changes include:

- New() no longer accepts a beam width parameter. There are
  instead GetModelBeamWidth() and SetModelBeamWidth()
  parameters on Model.
- Model's EnableDecoderWithLM() method has been replaced by
  EnableExternalScorer() and SetScorerAlphaBeta(). There's
  also a DisableExternalScorer() method.
- Instead of holding MetadataItems, the Metadata type now
  holds CandidateTranscripts, which hold TokenMetadata
  structs. WithMetadata-suffixed methods now take numResults
  parameters indicating the maximum number of transcripts to
  return.
- PrintVersions() has been replaced by Version(), which
  returns a string.
- Stream.IntermediateDecodeWithMetadata() has been added.

Also update instructions in README.md for v0.7.1.