### PR TITLE
Make more functions return errors and use slice lengths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Golang bindings for Mozilla's [DeepSpeech](https://github.com/mozilla/DeepSpeech
 - export CGO_CXXFLAGS="-I/tmp/deepspeech/include/"
 - export LD_LIBRARY_PATH=/tmp/deepspeech/lib/:$LD_LIBRARY_PATH
 
+Alternatively, copy the downloaded `libdeepspeech.so` and `deepspeech.h` files
+to directories that are searched by default, e.g. `/usr/local/lib` and
+`/usr/local/include`, respectively.
+
 ## Install astideepspeech
 
 Run the following command:

--- a/deepspeech.go
+++ b/deepspeech.go
@@ -1,8 +1,11 @@
+// package astideepspeech provides bindings for Mozilla's DeepSpeech speech-to-text library.
 package astideepspeech
 
 /*
+#cgo CXXFLAGS: -std=c++11
 #cgo LDFLAGS: -ldeepspeech
 #include "deepspeech_wrap.h"
+#include "stdlib.h"
 */
 import "C"
 import (
@@ -12,27 +15,31 @@ import (
 
 // Model provides an interface to a trained DeepSpeech model.
 type Model struct {
-	modelPath string
-	w         *C.ModelWrapper
+	w *C.ModelWrapper
 }
 
 // New creates a new Model.
 // modelPath is the path to the frozen model graph.
-func New(modelPath string) *Model {
-	return &Model{
-		modelPath: modelPath,
-		w:         C.New(C.CString(modelPath)),
+func New(modelPath string) (*Model, error) {
+	cModelPath := C.CString(modelPath)
+	defer C.free(unsafe.Pointer(cModelPath))
+
+	var ret C.int
+	w := C.New(cModelPath, &ret)
+	if ret != 0 {
+		C.Close(w)
+		return nil, errorFromCode(ret)
 	}
+	return &Model{w}, nil
 }
 
 // Close frees associated resources and destroys the model object.
-func (m *Model) Close() error {
+func (m *Model) Close() {
 	C.Close(m.w)
-	return nil
 }
 
 // GetModelBeamWidth returns the beam width value used by the model.
-// If SetModelBeamWidth was not called before, will return the default
+// If SetModelBeamWidth was not called before, it will return the default
 // value loaded from the model file.
 func (m *Model) GetModelBeamWidth() uint {
 	return uint(C.GetModelBeamWidth(m.w))
@@ -52,7 +59,9 @@ func (m *Model) GetModelSampleRate() int {
 // EnableExternalScorer enables decoding using an external scorer.
 // scorerPath is the path to the external scorer file.
 func (m *Model) EnableExternalScorer(scorerPath string) error {
-	return errorFromCode(C.EnableExternalScorer(m.w, C.CString(scorerPath)))
+	cScorerPath := C.CString(scorerPath)
+	defer C.free(unsafe.Pointer(cScorerPath))
+	return errorFromCode(C.EnableExternalScorer(m.w, cScorerPath))
 }
 
 // DisableExternalScorer disables decoding using an external scorer.
@@ -75,12 +84,14 @@ type sliceHeader struct {
 
 // SpeechToText uses the DeepSpeech model to convert speech to text.
 // buffer is 16-bit, mono raw audio signal at the appropriate sample rate (matching what the model was trained on).
-// bufferSize is the number of samples in the audio signal.
-func (m *Model) SpeechToText(buffer []int16, bufferSize uint) string {
-	str := C.STT(m.w, (*C.short)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&buffer)).Data)), C.uint(bufferSize))
+func (m *Model) SpeechToText(buffer []int16) (string, error) {
+	hdr := (*sliceHeader)(unsafe.Pointer(&buffer))
+	str := C.STT(m.w, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len))
+	if str == nil {
+		return "", errors.New("conversion failed")
+	}
 	defer C.FreeString(str)
-	retval := C.GoString(str)
-	return retval
+	return C.GoString(str), nil
 }
 
 // TokenMetadata stores text of an individual token, along with its timing information.
@@ -136,72 +147,103 @@ func (m *Metadata) Transcripts() []CandidateTranscript {
 }
 
 // Close frees the Metadata structure properly.
-func (m *Metadata) Close() error {
+func (m *Metadata) Close() {
 	C.FreeMetadata((*C.Metadata)(unsafe.Pointer(m)))
-	return nil
 }
 
 // SpeechToTextWithMetadata uses the DeepSpeech model to convert speech to text and
 // output results including metadata.
+//
 // buffer is a 16-bit, mono raw audio signal at the appropriate sample rate (matching what the model was trained on).
-// bufferSize is the number of samples in the audio signal.
 // numResults is the maximum number of CandidateTranscript structs to return. Returned value might be smaller than this.
-func (m *Model) SpeechToTextWithMetadata(buffer []int16, bufferSize, numResults uint) *Metadata {
-	return (*Metadata)(unsafe.Pointer(C.STTWithMetadata(m.w, (*C.short)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&buffer)).Data)), C.uint(bufferSize), C.uint(numResults))))
+// If an error is not returned, the returned metadata's Close method must be called later to free resources.
+func (m *Model) SpeechToTextWithMetadata(buffer []int16, numResults uint) (*Metadata, error) {
+	hdr := (*sliceHeader)(unsafe.Pointer(&buffer))
+	md := (*Metadata)(unsafe.Pointer(C.STTWithMetadata(
+		m.w, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len), C.uint(numResults))))
+	if md == nil {
+		return nil, errors.New("conversion failed")
+	}
+	return md, nil
 }
 
-// Stream represent a streaming state
+// Stream represents a streaming inference state.
 type Stream struct {
 	sw *C.StreamWrapper
 }
 
-// CreateStream creates a new audio stream
-//
-// mw               The DeepSpeech model to use
-func CreateStream(mw *Model) *Stream {
-	return &Stream{
-		sw: C.CreateStream(mw.w),
+// CreateStream creates a new streaming inference state.
+// m is the DeepSpeech model to use.
+// If an error is not returned, exactly one of the returned stream's FinishStream,
+// FinishStreamWithMetadata, or FreeStream methods must be called later to free resources.
+func CreateStream(m *Model) (*Stream, error) {
+	var ret C.int
+	sw := C.CreateStream(m.w, &ret)
+	if ret != 0 {
+		C.FreeStream(sw)
+		return nil, errorFromCode(ret)
 	}
+	return &Stream{sw}, nil
 }
 
-// FeedAudioContent Feed audio samples to an ongoing streaming inference.
-// aBuffer      An array of 16-bit, mono raw audio samples at the  appropriate sample rate.
-// aBufferSize  The number of samples in @p aBuffer.
-func (s *Stream) FeedAudioContent(buffer []int16, bufferSize uint) {
-	C.FeedAudioContent(s.sw, (*C.short)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&buffer)).Data)), C.uint(bufferSize))
+// FeedAudioContent feeds audio samples to an ongoing streaming inference.
+// buffer is an array of 16-bit, mono raw audio samples at the appropriate sample rate
+// (matching what the model was trained on).
+func (s *Stream) FeedAudioContent(buffer []int16) {
+	hdr := (*sliceHeader)(unsafe.Pointer(&buffer))
+	C.FeedAudioContent(s.sw, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len))
 }
 
-// IntermediateDecode Compute the intermediate decoding of an ongoing streaming inference.
+// IntermediateDecode computes the intermediate decoding of an ongoing streaming inference.
 // This is an expensive process as the decoder implementation isn't
 // currently capable of streaming, so it always starts from the beginning
 // of the audio.
-func (s *Stream) IntermediateDecode() string {
-	return C.GoString(C.IntermediateDecode(s.sw))
+func (s *Stream) IntermediateDecode() (string, error) {
+	// DS_IntermediateDecode isn't documented as returning null, but future-proofing this seems safer.
+	str := C.IntermediateDecode(s.sw)
+	if str == nil {
+		return "", errors.New("decoding failed")
+	}
+	defer C.FreeString(str)
+	return C.GoString(str), nil
 }
 
 // IntermediateDecodeWithMetadata computes the intermediate decoding of an
 // ongoing streaming inference, returning results including metadata.
 // numResults is the number of candidate transcripts to return.
-func (s *Stream) IntermediateDecodeWithMetadata(numResults uint) *Metadata {
-	return (*Metadata)(unsafe.Pointer(C.IntermediateDecodeWithMetadata(s.sw, C.uint(numResults))))
+// If an error is not returned, the metadata's Close method must be called.
+func (s *Stream) IntermediateDecodeWithMetadata(numResults uint) (*Metadata, error) {
+	md := (*Metadata)(unsafe.Pointer(C.IntermediateDecodeWithMetadata(s.sw, C.uint(numResults))))
+	if md == nil {
+		return nil, errors.New("decoding failed")
+	}
+	return md, nil
 }
 
-// FinishStream Signal the end of an audio signal to an ongoing streaming
-// inference, returns the STT result over the whole audio signal.
-func (s *Stream) FinishStream() string {
+// FinishStream computes the final decoding of an ongoing streaming inference and returns the result.
+// This signals the end of an ongoing streaming inference.
+func (s *Stream) FinishStream() (string, error) {
+	// DS_FinishStream isn't documented as returning null, but future-proofing this seems safer.
 	str := C.FinishStream(s.sw)
+	if str == nil {
+		return "", errors.New("decoding failed")
+	}
 	defer C.FreeString(str)
-	retval := C.GoString(str)
-	return retval
+	return C.GoString(str), nil
 }
 
-// FinishStreamWithMetadata Signal the end of an audio signal to an ongoing streaming
-// inference, returns extended metadata.
-func (s *Stream) FinishStreamWithMetadata(numResults uint) *Metadata {
-	return (*Metadata)(unsafe.Pointer(C.FinishStreamWithMetadata(s.sw, C.uint(numResults))))
+// FinishStreamWithMetadata computes the final decoding of an ongoing streaming inference and returns
+// results including metadata. This signals the end of an ongoing streaming inference.
+// If an error is not returned, the metadata's Close method must be called.
+func (s *Stream) FinishStreamWithMetadata(numResults uint) (*Metadata, error) {
+	md := (*Metadata)(unsafe.Pointer(C.FinishStreamWithMetadata(s.sw, C.uint(numResults))))
+	if md == nil {
+		return nil, errors.New("decoding failed")
+	}
+	return md, nil
 }
 
-// DiscardStream Destroy a streaming state without decoding the computed logits.
+// FreeStream destroys a streaming state without decoding the computed logits.
 // This can be used if you no longer need the result of an ongoing streaming
 // inference and don't want to perform a costly decode operation.
 func (s *Stream) FreeStream() {

--- a/deepspeech_wrap.h
+++ b/deepspeech_wrap.h
@@ -19,7 +19,7 @@ extern "C" {
     } Metadata;
 
     typedef void* ModelWrapper;
-    ModelWrapper* New(const char* aModelPath);
+    ModelWrapper* New(const char* aModelPath, int* errorOut);
     void Close(ModelWrapper* w);
     unsigned int GetModelBeamWidth(ModelWrapper* w);
     int SetModelBeamWidth(ModelWrapper* w, unsigned int aBeamWidth);
@@ -31,7 +31,7 @@ extern "C" {
     Metadata* STTWithMetadata(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize, unsigned int aNumResults);
 
     typedef void* StreamWrapper;
-    StreamWrapper* CreateStream(ModelWrapper* w);
+    StreamWrapper* CreateStream(ModelWrapper* w, int* errorOut);
     void FreeStream(StreamWrapper* sw);
     void FeedAudioContent(StreamWrapper* sw, const short* aBuffer, unsigned int aBufferSize);
     char* IntermediateDecode(StreamWrapper* sw);


### PR DESCRIPTION
Update the following functions to return errors reported by
libdeepspeech:

- New
- Model.SpeechToText
- Model.SpeechToTextWithMetadata
- Model.CreateStream
- Stream.IntermediateDecode
- Stream.IntermediateDecodeWithMetadata
- Stream.FinishStreamWithMetadata

Make Model.Close and Metadata.Close not return errors, as
the underlying C functions don't report errors.

Update Model.SpeechToText, Model.SpeechToTextWithMetadata,
and Stream.FeedAudioContent to not accept buffer size
parameters and instead just use slice lengths.

Free leaked strings in New, Model.EnableExternalScorer, and
Stream.IntermediateDecode, and set some pointers to null
after they've been freed in deepspeech.cpp to reduce the
chances of hard-to-debug use-after-free bugs.

Unrelated to all of this, add a -sample-rate flag to the
deepspeech example program and make it print to stdout
rather than stderr (to make it easier to pipe DeepSpeech's
stderr logging to /dev/null).