### PR TITLE
Rename functions to be more Go-like.

### DIFF
--- a/deepspeech.go
+++ b/deepspeech.go
@@ -25,9 +25,8 @@ func New(modelPath string) (*Model, error) {
 	defer C.free(unsafe.Pointer(cModelPath))
 
 	var ret C.int
-	w := C.New(cModelPath, &ret)
+	w := C.New(cModelPath, &ret) // returns nil on error
 	if ret != 0 {
-		C.Close(w)
 		return nil, errorFromCode(ret)
 	}
 	return &Model{w}, nil
@@ -35,25 +34,26 @@ func New(modelPath string) (*Model, error) {
 
 // Close frees associated resources and destroys the model object.
 func (m *Model) Close() {
-	C.Close(m.w)
+	C.Model_Close(m.w) // deletes m.w
+	m.w = nil
 }
 
-// GetModelBeamWidth returns the beam width value used by the model.
+// BeamWidth returns the beam width value used by the model.
 // If SetModelBeamWidth was not called before, it will return the default
 // value loaded from the model file.
-func (m *Model) GetModelBeamWidth() uint {
-	return uint(C.GetModelBeamWidth(m.w))
+func (m *Model) BeamWidth() uint {
+	return uint(C.Model_BeamWidth(m.w))
 }
 
-// SetModelBeamWidth sets the beam width value used by the model.
+// SetBeamWidth sets the beam width value used by the model.
 // A larger beam width value generates better results at the cost of decoding time.
-func (m *Model) SetModelBeamWidth(width uint) error {
-	return errorFromCode(C.SetModelBeamWidth(m.w, C.uint(width)))
+func (m *Model) SetBeamWidth(width uint) error {
+	return errorFromCode(C.Model_SetBeamWidth(m.w, C.uint(width)))
 }
 
-// GetModelSampleRate returns the sample rate that was used to produce the model file.
-func (m *Model) GetModelSampleRate() int {
-	return int(C.GetModelSampleRate(m.w))
+// SampleRate returns the sample rate that was used to produce the model file.
+func (m *Model) SampleRate() int {
+	return int(C.Model_SampleRate(m.w))
 }
 
 // EnableExternalScorer enables decoding using an external scorer.
@@ -61,18 +61,18 @@ func (m *Model) GetModelSampleRate() int {
 func (m *Model) EnableExternalScorer(scorerPath string) error {
 	cScorerPath := C.CString(scorerPath)
 	defer C.free(unsafe.Pointer(cScorerPath))
-	return errorFromCode(C.EnableExternalScorer(m.w, cScorerPath))
+	return errorFromCode(C.Model_EnableExternalScorer(m.w, cScorerPath))
 }
 
 // DisableExternalScorer disables decoding using an external scorer.
 func (m *Model) DisableExternalScorer() error {
-	return errorFromCode(C.DisableExternalScorer(m.w))
+	return errorFromCode(C.Model_DisableExternalScorer(m.w))
 }
 
 // SetScorerAlphaBeta sets hyperparameters alpha and beta of the external scorer.
 // alpha is the language model weight. beta is the word insertion weight.
 func (m *Model) SetScorerAlphaBeta(alpha, beta float32) error {
-	return errorFromCode(C.SetScorerAlphaBeta(m.w, C.float(alpha), C.float(beta)))
+	return errorFromCode(C.Model_SetScorerAlphaBeta(m.w, C.float(alpha), C.float(beta)))
 }
 
 // sliceHeader represents a slice header
@@ -86,7 +86,7 @@ type sliceHeader struct {
 // buffer is 16-bit, mono raw audio signal at the appropriate sample rate (matching what the model was trained on).
 func (m *Model) SpeechToText(buffer []int16) (string, error) {
 	hdr := (*sliceHeader)(unsafe.Pointer(&buffer))
-	str := C.STT(m.w, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len))
+	str := C.Model_STT(m.w, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len))
 	if str == nil {
 		return "", errors.New("conversion failed")
 	}
@@ -99,17 +99,17 @@ type TokenMetadata C.struct_TokenMetadata
 
 // Text returns the text corresponding to this token.
 func (tm *TokenMetadata) Text() string {
-	return C.GoString(C.TokenMetadata_GetText((*C.TokenMetadata)(unsafe.Pointer(tm))))
+	return C.GoString(C.TokenMetadata_Text((*C.TokenMetadata)(unsafe.Pointer(tm))))
 }
 
 // Timestep returns the position of the token in units of 20ms.
 func (tm *TokenMetadata) Timestep() uint {
-	return uint(C.TokenMetadata_GetTimestep((*C.TokenMetadata)(unsafe.Pointer(tm))))
+	return uint(C.TokenMetadata_Timestep((*C.TokenMetadata)(unsafe.Pointer(tm))))
 }
 
 // StartTime returns the position of the token in seconds.
 func (tm *TokenMetadata) StartTime() float32 {
-	return float32(C.TokenMetadata_GetStartTime((*C.TokenMetadata)(unsafe.Pointer(tm))))
+	return float32(C.TokenMetadata_StartTime((*C.TokenMetadata)(unsafe.Pointer(tm))))
 }
 
 // CandidateTranscript is a single transcript computed by the model,
@@ -117,12 +117,12 @@ func (tm *TokenMetadata) StartTime() float32 {
 type CandidateTranscript C.struct_CandidateTranscript
 
 func (ct *CandidateTranscript) NumTokens() uint {
-	return uint(C.CandidateTranscript_GetNumTokens((*C.CandidateTranscript)(unsafe.Pointer(ct))))
+	return uint(C.CandidateTranscript_NumTokens((*C.CandidateTranscript)(unsafe.Pointer(ct))))
 }
 
 func (ct *CandidateTranscript) Tokens() []TokenMetadata {
-	numTokens := uint(C.CandidateTranscript_GetNumTokens((*C.CandidateTranscript)(unsafe.Pointer(ct))))
-	allTokens := C.CandidateTranscript_GetTokens((*C.CandidateTranscript)(unsafe.Pointer(ct)))
+	numTokens := uint(C.CandidateTranscript_NumTokens((*C.CandidateTranscript)(unsafe.Pointer(ct))))
+	allTokens := C.CandidateTranscript_Tokens((*C.CandidateTranscript)(unsafe.Pointer(ct)))
 	return (*[1 << 30]TokenMetadata)(unsafe.Pointer(allTokens))[:numTokens:numTokens]
 }
 
@@ -130,25 +130,25 @@ func (ct *CandidateTranscript) Tokens() []TokenMetadata {
 // This is roughly the sum of the acoustic model logit values for each timestep/character that
 // contributed to the creation of this transcript.
 func (ct *CandidateTranscript) Confidence() float64 {
-	return float64(C.CandidateTranscript_GetConfidence((*C.CandidateTranscript)(unsafe.Pointer(ct))))
+	return float64(C.CandidateTranscript_Confidence((*C.CandidateTranscript)(unsafe.Pointer(ct))))
 }
 
 // Metadata holds an array of CandidateTranscript objects computed by the model.
 type Metadata C.struct_Metadata
 
 func (m *Metadata) NumTranscripts() uint {
-	return uint(C.Metadata_GetNumTranscripts((*C.Metadata)(unsafe.Pointer(m))))
+	return uint(C.Metadata_NumTranscripts((*C.Metadata)(unsafe.Pointer(m))))
 }
 
 func (m *Metadata) Transcripts() []CandidateTranscript {
-	numTranscripts := int32(C.Metadata_GetNumTranscripts((*C.Metadata)(unsafe.Pointer(m))))
-	allTranscripts := C.Metadata_GetTranscripts((*C.Metadata)(unsafe.Pointer(m)))
+	numTranscripts := int32(C.Metadata_NumTranscripts((*C.Metadata)(unsafe.Pointer(m))))
+	allTranscripts := C.Metadata_Transcripts((*C.Metadata)(unsafe.Pointer(m)))
 	return (*[1 << 30]CandidateTranscript)(unsafe.Pointer(allTranscripts))[:numTranscripts:numTranscripts]
 }
 
 // Close frees the Metadata structure properly.
 func (m *Metadata) Close() {
-	C.FreeMetadata((*C.Metadata)(unsafe.Pointer(m)))
+	C.Metadata_Close((*C.Metadata)(unsafe.Pointer(m)))
 }
 
 // SpeechToTextWithMetadata uses the DeepSpeech model to convert speech to text and
@@ -159,7 +159,7 @@ func (m *Metadata) Close() {
 // If an error is not returned, the returned metadata's Close method must be called later to free resources.
 func (m *Model) SpeechToTextWithMetadata(buffer []int16, numResults uint) (*Metadata, error) {
 	hdr := (*sliceHeader)(unsafe.Pointer(&buffer))
-	md := (*Metadata)(unsafe.Pointer(C.STTWithMetadata(
+	md := (*Metadata)(unsafe.Pointer(C.Model_STTWithMetadata(
 		m.w, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len), C.uint(numResults))))
 	if md == nil {
 		return nil, errors.New("conversion failed")
@@ -172,15 +172,13 @@ type Stream struct {
 	sw *C.StreamWrapper
 }
 
-// CreateStream creates a new streaming inference state.
-// m is the DeepSpeech model to use.
-// If an error is not returned, exactly one of the returned stream's FinishStream,
-// FinishStreamWithMetadata, or FreeStream methods must be called later to free resources.
-func CreateStream(m *Model) (*Stream, error) {
+// NewStream creates a new streaming inference state.
+// If an error is not returned, exactly one of the returned stream's Finish,
+// FinishWithMetadata, or Discard methods must be called later to free resources.
+func (m *Model) NewStream() (*Stream, error) {
 	var ret C.int
-	sw := C.CreateStream(m.w, &ret)
+	sw := C.Model_NewStream(m.w, &ret) // returns nil on error
 	if ret != 0 {
-		C.FreeStream(sw)
 		return nil, errorFromCode(ret)
 	}
 	return &Stream{sw}, nil
@@ -191,7 +189,7 @@ func CreateStream(m *Model) (*Stream, error) {
 // (matching what the model was trained on).
 func (s *Stream) FeedAudioContent(buffer []int16) {
 	hdr := (*sliceHeader)(unsafe.Pointer(&buffer))
-	C.FeedAudioContent(s.sw, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len))
+	C.Stream_FeedAudioContent(s.sw, (*C.short)(unsafe.Pointer(hdr.Data)), C.uint(hdr.Len))
 }
 
 // IntermediateDecode computes the intermediate decoding of an ongoing streaming inference.
@@ -200,7 +198,7 @@ func (s *Stream) FeedAudioContent(buffer []int16) {
 // of the audio.
 func (s *Stream) IntermediateDecode() (string, error) {
 	// DS_IntermediateDecode isn't documented as returning null, but future-proofing this seems safer.
-	str := C.IntermediateDecode(s.sw)
+	str := C.Stream_IntermediateDecode(s.sw)
 	if str == nil {
 		return "", errors.New("decoding failed")
 	}
@@ -213,18 +211,20 @@ func (s *Stream) IntermediateDecode() (string, error) {
 // numResults is the number of candidate transcripts to return.
 // If an error is not returned, the metadata's Close method must be called.
 func (s *Stream) IntermediateDecodeWithMetadata(numResults uint) (*Metadata, error) {
-	md := (*Metadata)(unsafe.Pointer(C.IntermediateDecodeWithMetadata(s.sw, C.uint(numResults))))
+	md := (*Metadata)(unsafe.Pointer(C.Stream_IntermediateDecodeWithMetadata(s.sw, C.uint(numResults))))
 	if md == nil {
 		return nil, errors.New("decoding failed")
 	}
 	return md, nil
 }
 
-// FinishStream computes the final decoding of an ongoing streaming inference and returns the result.
+// Finish computes the final decoding of an ongoing streaming inference and returns the result.
 // This signals the end of an ongoing streaming inference.
-func (s *Stream) FinishStream() (string, error) {
+func (s *Stream) Finish() (string, error) {
 	// DS_FinishStream isn't documented as returning null, but future-proofing this seems safer.
-	str := C.FinishStream(s.sw)
+	str := C.Stream_Finish(s.sw) // deletes s.sw
+	s.sw = nil
+
 	if str == nil {
 		return "", errors.New("decoding failed")
 	}
@@ -232,22 +232,25 @@ func (s *Stream) FinishStream() (string, error) {
 	return C.GoString(str), nil
 }
 
-// FinishStreamWithMetadata computes the final decoding of an ongoing streaming inference and returns
+// FinishWithMetadata computes the final decoding of an ongoing streaming inference and returns
 // results including metadata. This signals the end of an ongoing streaming inference.
 // If an error is not returned, the metadata's Close method must be called.
-func (s *Stream) FinishStreamWithMetadata(numResults uint) (*Metadata, error) {
-	md := (*Metadata)(unsafe.Pointer(C.FinishStreamWithMetadata(s.sw, C.uint(numResults))))
+func (s *Stream) FinishWithMetadata(numResults uint) (*Metadata, error) {
+	md := (*Metadata)(unsafe.Pointer(C.Stream_FinishWithMetadata(s.sw, C.uint(numResults)))) // deletes s.sw
+	s.sw = nil
+
 	if md == nil {
 		return nil, errors.New("decoding failed")
 	}
 	return md, nil
 }
 
-// FreeStream destroys a streaming state without decoding the computed logits.
+// Discard destroys a streaming state without decoding the computed logits.
 // This can be used if you no longer need the result of an ongoing streaming
 // inference and don't want to perform a costly decode operation.
-func (s *Stream) FreeStream() {
-	C.FreeStream(s.sw)
+func (s *Stream) Discard() {
+	C.Stream_Discard(s.sw) // deletes s.sw
+	s.sw = nil
 }
 
 // Version returns the version of the DeepSpeech C library.

--- a/deepspeech/main.go
+++ b/deepspeech/main.go
@@ -66,11 +66,11 @@ func main() {
 	defer m.Close()
 
 	if *printSampleRate {
-		fmt.Println(m.GetModelSampleRate())
+		fmt.Println(m.SampleRate())
 		return
 	}
 
-	if err := m.SetModelBeamWidth(beamWidth); err != nil {
+	if err := m.SetBeamWidth(beamWidth); err != nil {
 		log.Fatal("Failed setting beam width: ", err)
 	}
 	if *scorer != "" {

--- a/deepspeech_wrap.h
+++ b/deepspeech_wrap.h
@@ -20,38 +20,38 @@ extern "C" {
 
     typedef void* ModelWrapper;
     ModelWrapper* New(const char* aModelPath, int* errorOut);
-    void Close(ModelWrapper* w);
-    unsigned int GetModelBeamWidth(ModelWrapper* w);
-    int SetModelBeamWidth(ModelWrapper* w, unsigned int aBeamWidth);
-    int GetModelSampleRate(ModelWrapper* w);
-    int EnableExternalScorer(ModelWrapper* w, const char* aScorerPath);
-    int DisableExternalScorer(ModelWrapper* w);
-    int SetScorerAlphaBeta(ModelWrapper* w, float aAlpha, float aBeta);
-    char* STT(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize);
-    Metadata* STTWithMetadata(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize, unsigned int aNumResults);
+    void Model_Close(ModelWrapper* w);
+    unsigned int Model_BeamWidth(ModelWrapper* w);
+    int Model_SetBeamWidth(ModelWrapper* w, unsigned int aBeamWidth);
+    int Model_SampleRate(ModelWrapper* w);
+    int Model_EnableExternalScorer(ModelWrapper* w, const char* aScorerPath);
+    int Model_DisableExternalScorer(ModelWrapper* w);
+    int Model_SetScorerAlphaBeta(ModelWrapper* w, float aAlpha, float aBeta);
+    char* Model_STT(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize);
+    Metadata* Model_STTWithMetadata(ModelWrapper* w, const short* aBuffer, unsigned int aBufferSize, unsigned int aNumResults);
 
     typedef void* StreamWrapper;
-    StreamWrapper* CreateStream(ModelWrapper* w, int* errorOut);
-    void FreeStream(StreamWrapper* sw);
-    void FeedAudioContent(StreamWrapper* sw, const short* aBuffer, unsigned int aBufferSize);
-    char* IntermediateDecode(StreamWrapper* sw);
-    Metadata* IntermediateDecodeWithMetadata(StreamWrapper* sw, unsigned int aNumResults);
-    char* FinishStream(StreamWrapper* sw);
-    Metadata* FinishStreamWithMetadata(StreamWrapper* sw, unsigned int aNumResults);
+    StreamWrapper* Model_NewStream(ModelWrapper* w, int* errorOut);
+    void Stream_Discard(StreamWrapper* sw);
+    void Stream_FeedAudioContent(StreamWrapper* sw, const short* aBuffer, unsigned int aBufferSize);
+    char* Stream_IntermediateDecode(StreamWrapper* sw);
+    Metadata* Stream_IntermediateDecodeWithMetadata(StreamWrapper* sw, unsigned int aNumResults);
+    char* Stream_Finish(StreamWrapper* sw);
+    Metadata* Stream_FinishWithMetadata(StreamWrapper* sw, unsigned int aNumResults);
 
-    const CandidateTranscript* Metadata_GetTranscripts(Metadata* m);
-    unsigned int Metadata_GetNumTranscripts(Metadata* m);
+    const CandidateTranscript* Metadata_Transcripts(Metadata* m);
+    unsigned int Metadata_NumTranscripts(Metadata* m);
+    void Metadata_Close(Metadata* m);
 
-    const TokenMetadata* CandidateTranscript_GetTokens(CandidateTranscript* ct);
-    unsigned int CandidateTranscript_GetNumTokens(CandidateTranscript* ct);
-    double CandidateTranscript_GetConfidence(CandidateTranscript* ct);
+    const TokenMetadata* CandidateTranscript_Tokens(CandidateTranscript* ct);
+    unsigned int CandidateTranscript_NumTokens(CandidateTranscript* ct);
+    double CandidateTranscript_Confidence(CandidateTranscript* ct);
 
-    const char* TokenMetadata_GetText(TokenMetadata* tm);
-    unsigned int TokenMetadata_GetTimestep(TokenMetadata* tm);
-    float TokenMetadata_GetStartTime(TokenMetadata* tm);
+    const char* TokenMetadata_Text(TokenMetadata* tm);
+    unsigned int TokenMetadata_Timestep(TokenMetadata* tm);
+    float TokenMetadata_StartTime(TokenMetadata* tm);
 
     void FreeString(char* s);
-    void FreeMetadata(Metadata* m);
     char* Version();
     char* ErrorCodeToErrorMessage(int aErrorCode);
 


### PR DESCRIPTION
Model.GetModelBeamWidth -> Model.BeamWidth
Model.SetModelBeamWidth -> Model.SetBeamWidth
Model.GetModelSampleRate -> Model.SampleRate
CreateStream -> Model.NewStream
Stream.FinishStream -> Stream.Finish
Stream.FinishStreamWithMetadata -> Stream.FinishWithMetadata
Stream.FreeStream -> Stream.Discard

Also rename C++ functions and methods to be more closely
aligned with Go functions.

Finally, move memory management of C++ wrapper structs into
deepspeech.cpp where possible: New and Model_NewStream now
delete wrapper structs on error, and Stream_Finish,
Stream_FinishWithMetadata, and Stream_Discard delete
wrappers unconditionally. It looks like StreamWrappers were
previously being leaked when Finish methods were called.